### PR TITLE
Update Cuda GPG repo key

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -79,7 +79,7 @@ stages:
         steps:
           - script: nvidia-cuda-cudnn-opengl/build.sh nvidia/cuda:$(base_tag) $(azure_dtr)/cuda-cudnn-opengl:$(tag)
             displayName: "Build cuda opengl docker"
-          - script: cd ci && ./build_cuda_cpp.sh $(azure_dtr)/cuda-cudnn-opengl:$(tag) $(azure_dtr)/cuda-cpp:$(tag) $(cuda)
+          - script: cd ci && ./build_cuda_cpp.sh $(azure_dtr)/cuda-cudnn-opengl:$(tag) $(azure_dtr)/cuda-cpp:$(tag) $(cuda) ubuntu1804 x86_64
             displayName: "Build cuda-cpp docker"
 
           - task: Docker@2

--- a/ci/build_cuda_cpp.sh
+++ b/ci/build_cuda_cpp.sh
@@ -4,6 +4,8 @@ repo_dir="${ci_dir}/.."
 base_image=$1
 target_image=$2
 cuda_version=$3
+distro=$4
+arch=$5
 
 if [[ -z "${base_image}" ]]; then
     base_image=" xmindai/cuda-cudnn-opengl:ubuntu18.04-10.0-cudnn7"  # xmindai/cuda-cudnn-opengl:ubuntu18.04-10.0-cudnn7
@@ -21,7 +23,7 @@ fi
 set -e
 
 cd "${repo_dir}/general-development"
-./build.sh ${base_image} temp-dev-img
+./build.sh ${base_image} temp-dev-img ${distro} ${arch}
 
 cd "${repo_dir}/user-layer"
 ./build.sh temp-dev-img temp-dev-user-img

--- a/general-development/Dockerfile
+++ b/general-development/Dockerfile
@@ -1,6 +1,14 @@
 ARG from
 FROM $from
 
+#Update Cuda GPG key
+ARG distro
+ARG arch
+
+RUN apt-key del 7fa2af80
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/$distro/$arch/cuda-keyring_1.0-1_all.deb
+RUN dpkg -i cuda-keyring_1.0-1_all.deb
+
 # Install make and compilers
 RUN DEBIAN_FRONTEND=noninteractive apt update && \
     DEBIAN_FRONTEND=noninteractive apt upgrade -y && \

--- a/general-development/Dockerfile
+++ b/general-development/Dockerfile
@@ -3,11 +3,10 @@ FROM $from
 
 #Update Cuda GPG key
 ARG distro
-ARG arch
 
-RUN apt-key del 7fa2af80
-RUN wget https://developer.download.nvidia.com/compute/cuda/repos/$distro/$arch/cuda-keyring_1.0-1_all.deb
-RUN dpkg -i cuda-keyring_1.0-1_all.deb
+RUN apt-key del 7fa2af80 && \
+    wget https://developer.download.nvidia.com/compute/cuda/repos/$distro/x86_64/cuda-keyring_1.0-1_all.deb && \
+    dpkg -i cuda-keyring_1.0-1_all.deb
 
 # Install make and compilers
 RUN DEBIAN_FRONTEND=noninteractive apt update && \

--- a/general-development/build.sh
+++ b/general-development/build.sh
@@ -2,6 +2,8 @@
 
 base_image=$1
 target_image=$2
+distro=$3
+arch=$4
 
 if [[ -z "${base_image}" ]]; then
     echo "No base image given" 1>&2
@@ -15,4 +17,4 @@ fi
 
 set -e
 
-docker build -t ${target_image} --build-arg from=${base_image} .
+docker build -t ${target_image} --build-arg from=${base_image} --build-arg distro=${distro} --build-arg arch=${arch} .

--- a/general-development/build.sh
+++ b/general-development/build.sh
@@ -2,8 +2,9 @@
 
 base_image=$1
 target_image=$2
-distro=$3
-arch=$4
+
+tag=$(sed 's/.*:\(.*\)-.*/\1/' <<< "$base_image")
+distro=$(sed 's/\.//g' <<< "$tag")
 
 if [[ -z "${base_image}" ]]; then
     echo "No base image given" 1>&2
@@ -17,4 +18,4 @@ fi
 
 set -e
 
-docker build -t ${target_image} --build-arg from=${base_image} --build-arg distro=${distro} --build-arg arch=${arch} .
+docker build -t ${target_image} --build-arg from=${base_image} --build-arg distro=${distro} .


### PR DESCRIPTION
Arguments added to handle different base image os versions and architecture. Updating the gpg key only in the base image resulted in the following error:

```
E: Conflicting values set for option Signed-By regarding source https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /: /usr/share/keyrings/cuda-archive-keyring.gpg != 
E: The list of sources could not be read.
The command '/bin/sh -c DEBIAN_FRONTEND=noninteractive apt update &&     DEBIAN_FRONTEND=noninteractive apt upgrade -y &&     DEBIAN_FRONTEND=noninteractive apt install -y     autoconf automake bison build-essential byacc bzip2 ca-certificates ccache clang cmake cowsay curl dnsutils     emacs flake8 flex gcc gdb gdbserver git git-lfs htop inetutils-ping iproute2 less libcanberra-gtk-module     libfontconfig1 libfreetype6-dev libgtk2.0-0 libjpeg-dev libpng-dev libprotoc-dev libx11-6 libxext-dev     libxrender-dev libxtst-dev lldb llvm mesa-utils nano net-tools openssh-client openssh-server protobuf-compiler     rsync sl software-properties-common sudo tcpdump telnet x11vnc xvfb     tmux traceroute tree valgrind vim wget xauth zsh &&     add-apt-repository ppa:git-core/ppa -y &&     DEBIAN_FRONTEND=noninteractive apt install -y git &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     rm -rf /tmp/*' returned a non-zero code: 100
##[error]Bash exited with code '100'.
```